### PR TITLE
Fix: allow custom FAQCard titles and update TailwindForge pages

### DIFF
--- a/app/tailwind-forge/advanced/TailwindForgeAdvancedPage.tsx
+++ b/app/tailwind-forge/advanced/TailwindForgeAdvancedPage.tsx
@@ -31,7 +31,7 @@ export default function TailwindForgeAdvancedPage() {
         breadcrumbs={[
           { label: "Home", href: "/" },
           { label: "Tools", href: "/tools" },
-          {label: "TailwindForge", href: "/tailwind-forge"},
+          { label: "TailwindForge", href: "/tailwind-forge" },
           { label: "Advanced", href: "/tailwind-forge/advanced" },
         ]}
       />
@@ -86,7 +86,7 @@ export default function TailwindForgeAdvancedPage() {
                     <Button variant="default" className="w-full cursor-pointer">
                       <span className="mr-2">🛠</span> Go to Migration Mode
                     </Button>
-                  </Link>                  
+                  </Link>
                 </div>
 
                 {/* Actions */}
@@ -112,7 +112,21 @@ export default function TailwindForgeAdvancedPage() {
             </Card>
 
             <ExportCard />
-            <FAQCard faqs={tailwindForgeFAQs.filter(faq => faq.id.startsWith("advanced"))} />
+
+            {/* FAQ Section */}
+            <Card>
+              <CardHeader>
+                <CardTitle>Frequently Asked Questions</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <FAQCard
+                  title="Advanced Mode FAQs"
+                  faqs={tailwindForgeFAQs.filter((faq) =>
+                    faq.id.startsWith("advanced")
+                  )}
+                />
+              </CardContent>
+            </Card>
           </div>
         </div>
       </div>

--- a/app/tailwind-forge/basic/TailwindForgeBasicPage.tsx
+++ b/app/tailwind-forge/basic/TailwindForgeBasicPage.tsx
@@ -118,7 +118,12 @@ export default function TailwindForgeBasicPage() {
             <ExportCard />
 
             {/* FAQ */}
-            <FAQCard faqs={tailwindForgeFAQs.filter(faq => faq.id.startsWith("basic"))} />
+            {/* FAQ Section */}
+<FAQCard
+  title="Basic Mode FAQs"
+  faqs={tailwindForgeFAQs.filter((faq) => faq.id.startsWith("basic"))}
+/>
+
           </div>
         </div>
       </div>

--- a/app/tailwind-forge/migration/page.tsx
+++ b/app/tailwind-forge/migration/page.tsx
@@ -74,10 +74,10 @@ export default function TailwindMigrationPage() {
 
   return (
     <div className="container mx-auto px-4 py-16">
-      <Counter
-        page="tailwindforge-migration"
-        className="text-right px-10 py-2"
-      />
+      {/* Analytics Counter */}
+      <Counter page="tailwindforge-migration" className="text-right px-10 py-2" />
+
+      {/* Header */}
       <HeaderCard
         title="TailwindForge Migration"
         icon={PaintBucket}
@@ -88,7 +88,9 @@ export default function TailwindMigrationPage() {
           { label: "Migration", href: "/tailwind-forge/migration" },
         ]}
       />
+
       <div className="mt-6 space-y-6">
+        {/* Mode Selection */}
         <Card>
           <CardHeader>
             <CardTitle>Mode Selection</CardTitle>
@@ -108,6 +110,8 @@ export default function TailwindMigrationPage() {
             </div>
           </CardContent>
         </Card>
+
+        {/* Migration Tool */}
         <Card>
           <CardHeader>
             <CardTitle>Tailwind v3 ➝ v4 Migration Tool</CardTitle>
@@ -115,17 +119,15 @@ export default function TailwindMigrationPage() {
           <CardContent className="space-y-4">
             <p className="text-muted-foreground">
               Paste your Tailwind v3 config and convert colors to Tailwind v4
-              @theme inline CSS.
+              <code className="px-1 py-0.5 bg-muted rounded text-xs">@theme</code> inline CSS.
             </p>
-            <div className="flex gap-2">
+
+            {/* Action Buttons */}
+            <div className="flex flex-wrap gap-2">
               <Button onClick={handleConvert} className="cursor-pointer">
                 Convert
               </Button>
-              <Button
-                variant="ghost"
-                onClick={loadSampleConfig}
-                className="cursor-pointer"
-              >
+              <Button variant="ghost" onClick={loadSampleConfig} className="cursor-pointer">
                 Load Sample
               </Button>
               <Button
@@ -155,6 +157,8 @@ export default function TailwindMigrationPage() {
                 Reset
               </Button>
             </div>
+
+            {/* Input / Output Grid */}
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
               <div>
                 <h3 className="text-md font-semibold mb-2">Input Config</h3>
@@ -167,9 +171,7 @@ export default function TailwindMigrationPage() {
                 />
               </div>
               <div>
-                <h3 className="text-md font-semibold mb-2">
-                  Tailwind v4 Theme Output
-                </h3>
+                <h3 className="text-md font-semibold mb-2">Tailwind v4 Theme Output</h3>
                 <Textarea
                   className="min-h-[400px] font-mono text-sm"
                   value={output}
@@ -180,18 +182,12 @@ export default function TailwindMigrationPage() {
             </div>
           </CardContent>
         </Card>
-        <Card>
-          <CardHeader>
-            <CardTitle>Frequently Asked Questions</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <FAQCard
-              faqs={tailwindForgeFAQs.filter((faq) =>
-                faq.id.startsWith("migration")
-              )}
-            />
-          </CardContent>
-        </Card>
+
+        {/* FAQ Section */}
+        <FAQCard
+          title="Migration Mode FAQs"
+          faqs={tailwindForgeFAQs.filter((faq) => faq.id.startsWith("migration"))}
+        />
       </div>
     </div>
   );

--- a/components/FAQCard.tsx
+++ b/components/FAQCard.tsx
@@ -5,7 +5,7 @@ import { ChevronDown, ChevronUp } from "lucide-react";
 import { FAQCardProps } from "@/types/types";
 
 export const FAQCard = ({
-  title = "Frequently Asked Questions",
+  title,
   faqs,
   icon: Icon,
   defaultOpenIndex = -1,
@@ -22,7 +22,7 @@ export const FAQCard = ({
       <CardHeader>
         <CardTitle className="text-lg flex items-center gap-2">
           {Icon && <Icon className="h-5 w-5" />}
-          {title}
+          {title || "Frequently Asked Questions"}
         </CardTitle>
       </CardHeader>
       <CardContent>


### PR DESCRIPTION
 Description
- Enhanced FAQCard component to support custom titles.
- Updated TailwindForge Basic, Advanced, and Migration pages to use specific FAQ titles.
- Improved the user experience by making FAQ sections clearer and more structured.

Changes Made
- Modified `FAQCard.tsx` to accept a `title` prop.
- Updated `TailwindForgeBasicPage.tsx`, `TailwindForgeAdvancedPage.tsx`, and `page.tsx` (migration) to use custom FAQ titles.
- Verified UI alignment and FAQ expand/collapse functionality.

Testing
- Checked locally that:
  - Each page shows its respective FAQ title.
  - Expand/Collapse works correctly for all FAQs.
  - Default state (when no FAQs exist) is displayed properly.

Video solution

https://github.com/user-attachments/assets/8054aac9-82fd-4a4c-a015-18d597078df6


Closing 
Fixes #8


